### PR TITLE
harden: sanitize child_process call in audioedit.js...

### DIFF
--- a/plugins/Audio-Edit/audioedit.js
+++ b/plugins/Audio-Edit/audioedit.js
@@ -1,6 +1,6 @@
 const { bmbtz } = require("../../devbmb/bmbtz");
 const fs = require("fs");
-const { exec } = require("child_process");
+const { execFile } = require("child_process");
 
 const filename = `${Math.random().toString(36)}`;
 
@@ -39,9 +39,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = "-af atempo=4/4,asettingsrate=44500*2/3";
+  const settings = ["-af", "atempo=4/4,asettingsrate=44500*2/3"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);
@@ -65,9 +65,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = "-af equalizer=f=18:width_type=o:width=2:g=14";
+  const settings = ["-af", "equalizer=f=18:width_type=o:width=2:g=14"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);
@@ -91,9 +91,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = '-filter_complex "areverse"';
+  const settings = ["-filter_complex", "areverse"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);
@@ -117,9 +117,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = '-filter:a "atempo=0.8,asettingsrate=44100"';
+  const settings = ["-filter:a", "atempo=0.8,asettingsrate=44100"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);
@@ -143,9 +143,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = '-filter:a "atempo=0.9,asettingsrate=65100"';
+  const settings = ["-filter:a", "atempo=0.9,asettingsrate=65100"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);
@@ -169,9 +169,9 @@ bmbtz({
   if (!msgRepondu || !msgRepondu.audioMessage) return repondre("❗ Please mention an audio");
   const media = await client.downloadAndSaveMediaMessage(msgRepondu.audioMessage);
   const ran = `${filename}.mp3`;
-  const settings = '-filter:a "atempo=1.07,asettingsrate=44100*1.20"';
+  const settings = ["-filter:a", "atempo=1.07,asettingsrate=44100*1.20"];
 
-  exec(`ffmpeg -i ${media} ${settings} ${ran}`, (err) => {
+  execFile("ffmpeg", ["-i", media, ...settings, ran], (err) => {
     fs.unlinkSync(media);
     if (err) return repondre("❌ Error during processing: " + err);
     const buffer = fs.readFileSync(ran);


### PR DESCRIPTION
## Summary
Harden input handling in `plugins/Audio-Edit/audioedit.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `plugins/Audio-Edit/audioedit.js:44` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `client`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `plugins/Audio-Edit/audioedit.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
